### PR TITLE
Update min python version and add tomli dependency 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,15 +20,17 @@ build:
 
 requirements:
   host:
-    - python >=2.7
+    - python >=3.7
     - pip
   run:
-    - python >=2.7
+    - tomli >=2.0.1
+    - python >=3.7
 
 test:
   commands:
     - yapf --help
     - yapf --version
+    - pip check
 
 about:
   home: https://github.com/google/yapf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   entry_points:
     - yapf = yapf:run_main
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ test:
     - yapf --help
     - yapf --version
     - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/google/yapf


### PR DESCRIPTION
Patching https://github.com/conda-forge/yapf-feedstock/pull/36 to include the `tomli` dependency to fix error like `yapf 0.33.0 requires tomli, which is not installed` at https://github.com/conda-forge/mmengine-feedstock/pull/1#issuecomment-1529136148. 

Also update minimum Python version to 3.7 as per https://github.com/google/yapf/blob/30e2a95354244439a083aa010d0032af2a4e9e16/setup.py#L81, and added `pip check` to the tests.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
